### PR TITLE
dent/: Make man pages work on Ubuntu

### DIFF
--- a/dent/dent
+++ b/dent/dent
@@ -66,10 +66,6 @@ packages() {
     export LC_ALL=C
     if type apt 2>/dev/null; then
         packages_apt
-        #   XXX These don't seem to fix the subsequent "Your name and email
-        #   address were configured automatically" message.
-        git config --global user.name 'dent root user'
-        git config --global user.email 'root@dent.nonexistent'
         ( cd /etc \
             && sed -i -e '/en_US/s/^# //' -e '/ja_JP/s/^# //' /etc/locale.gen \
             && etckeeper commit -m 'Enable UTF-8 and other locales' \
@@ -88,8 +84,14 @@ packages_apt() {
     echo '-- Package updates/installs'
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
-    #   Install etckeeper first so we have a record of the following installs.
-    apt-get -y install git etckeeper
+    #   We must install git and set user.name/email before installing
+    #   etckeeper or etckeeper will be unable to commit.
+    apt-get -y install git
+    git config --global user.name 'dent root user'
+    git config --global user.email 'root@dent.nonexistent'
+    #   Install etckeeper as early as posible so we have a record of
+    #   the following installs.
+    apt-get -y install etckeeper
     #   ≤14.04 always configures bzr, even if git is installed instead
     sed -i -e '/^VCS=/s/.*/VCS="git"/' /etc/etckeeper/etckeeper.conf
     etckeeper init

--- a/dent/dent
+++ b/dent/dent
@@ -100,6 +100,13 @@ packages_apt() {
     #   of date in a week or two anyway and the user will still have
     #   to run dist-upgrade himself on new containers.
     #apt-get -y dist-upgrade
+    #   Ubuntu images appear to turn off installation of manpages and
+    #   other useful stuff.
+    [ -f "/etc/dpkg/dpkg.cfg.d/excludes" ] && {
+        cd /etc
+        git rm -f /etc/dpkg/dpkg.cfg.d/excludes
+        etckeeper commit -m 'Re-enable installs of manpages, etc.'
+    }
     #   We install a minimal set of packages here because
     #   the user will use `distro` to install what he needs.
     apt-get -y install $UNIVERSAL_PKGS locales manpages


### PR DESCRIPTION
A dpkg configuration file in the Ubuntu image prevents man pages from working properly. This fix comments out the problematic exclusion.